### PR TITLE
leaderboard webpage

### DIFF
--- a/frontend/src/api/leaderboard.ts
+++ b/frontend/src/api/leaderboard.ts
@@ -1,0 +1,64 @@
+
+
+
+const fetcher = (url: string, options: RequestInit = {}) =>
+  fetch(url, options)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`HTTP error! Status: ${res.status}`);
+      }
+      return res.json();
+    })
+    .catch((error) => {
+      console.error("Fetcher error:", error);
+      throw error;
+    });
+
+const discordLookup = async (userName: string) => {
+    const discordUrl = "https://server.rakibshahid.com/api/discord_lookup";
+    const discordOptions: RequestInit = {
+      method: "GET",
+      headers: {
+        "discord-username": userName 
+        }
+    };
+    const response = await fetch(discordUrl, discordOptions);
+    return response;
+}
+
+const leetcodeLookup = async (userName: string) => {
+    const leetcodeUrl = "https://server.rakibshahid.com/api/leetcode_lookup";
+    const leetcodeOptions: RequestInit = {
+      method: "GET",
+      headers: {
+        "leetcode-username": userName,
+      },
+    };
+    return await fetch(leetcodeUrl, leetcodeOptions);
+}
+
+const fetchUser = async (userName: string) => {
+    // The function will first try to fetch the discord userName and if there is no match it willf fetch the leetcode userName
+    let response = await discordLookup(userName);
+    if (!response.ok) {
+        response = await leetcodeLookup(userName);
+    }
+    if (!response.ok) {
+        throw new Error("Both APIs failed to fetch user data.");
+    }
+
+    const output = await response.json();
+    return output;
+}
+
+const fetchLeaderboard = async () => {
+    const leaderboardUrl = "https://server.rakibshahid.com/leaderboard";
+    return fetcher(leaderboardUrl);
+}
+
+const fetchLeaderboardHistory = async () => {
+    const historyUrl = "https://server.rakibshahid.com/leaderboard/leaderboard_history";
+    return fetcher(historyUrl);
+}
+
+export { fetchUser, fetchLeaderboard, fetchLeaderboardHistory, fetcher };

--- a/frontend/src/api/leaderboard.ts
+++ b/frontend/src/api/leaderboard.ts
@@ -1,6 +1,4 @@
-
-
-
+const BASE_URL = import.meta.env.VITE_LEETCODE_API_BASE;
 const fetcher = (url: string, options: RequestInit = {}) =>
   fetch(url, options)
     .then((res) => {
@@ -14,34 +12,28 @@ const fetcher = (url: string, options: RequestInit = {}) =>
       throw error;
     });
 
-const discordLookup = async (userName: string) => {
-    const discordUrl = "https://server.rakibshahid.com/api/discord_lookup";
-    const discordOptions: RequestInit = {
-      method: "GET",
-      headers: {
-        "discord-username": userName 
-        }
-    };
-    const response = await fetch(discordUrl, discordOptions);
-    return response;
-}
+const lookupUser = async (
+  type: "discord" | "leetcode",
+  userName: string
+) => {
+  const url = `${BASE_URL}/api/${type}_lookup`;
 
-const leetcodeLookup = async (userName: string) => {
-    const leetcodeUrl = "https://server.rakibshahid.com/api/leetcode_lookup";
-    const leetcodeOptions: RequestInit = {
-      method: "GET",
-      headers: {
-        "leetcode-username": userName,
-      },
-    };
-    return await fetch(leetcodeUrl, leetcodeOptions);
-}
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      [`${type}-username`]: userName,
+    },
+  });
+
+  return response;
+};
+
 
 const fetchUser = async (userName: string) => {
     // The function will first try to fetch the discord userName and if there is no match it willf fetch the leetcode userName
-    let response = await discordLookup(userName);
+    let response = await lookupUser("discord", userName);
     if (!response.ok) {
-        response = await leetcodeLookup(userName);
+        response = await lookupUser("leetcode", userName);
     }
     if (!response.ok) {
         throw new Error("Both APIs failed to fetch user data.");
@@ -52,12 +44,12 @@ const fetchUser = async (userName: string) => {
 }
 
 const fetchLeaderboard = async () => {
-    const leaderboardUrl = "https://server.rakibshahid.com/leaderboard";
+    const leaderboardUrl = `${BASE_URL}/leaderboard`;
     return fetcher(leaderboardUrl);
 }
 
 const fetchLeaderboardHistory = async () => {
-    const historyUrl = "https://server.rakibshahid.com/leaderboard/leaderboard_history";
+    const historyUrl = `${BASE_URL}/leaderboard/leaderboard_history`;
     return fetcher(historyUrl);
 }
 

--- a/frontend/src/components/leaderboard/controls.tsx
+++ b/frontend/src/components/leaderboard/controls.tsx
@@ -1,0 +1,67 @@
+export function LeaderboardControls({
+  isAllTime,
+  onToggle,
+  searchQuery,
+  onSearchChange,
+  onSearchSubmit,
+  searchLoading,
+  searchError,
+}: {
+  isAllTime: boolean;
+  onToggle: (allTime: boolean) => void;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  onSearchSubmit: (e: React.FormEvent) => void;
+  searchLoading: boolean;
+  searchError: string | null;
+}) {
+  return (
+    <div className="flex items-start justify-between flex-wrap gap-4 mb-6">
+      <div className="flex gap-2">
+        {(["Current Rankings", "All-Time"] as const).map((label) => {
+          const active = label === "All-Time" ? isAllTime : !isAllTime;
+          return (
+            <button
+              key={label}
+              onClick={() => onToggle(label === "All-Time")}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+                active
+                  ? "bg-[#A855F7] text-white"
+                  : "bg-white border border-slate-200 text-[#71717A] hover:text-[#09090B]"
+              }`}
+              style={{ fontFamily: "'Lexend', sans-serif" }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <form onSubmit={onSearchSubmit} className="flex flex-col items-end gap-1">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Discord or LeetCode username"
+            className="bg-white border border-slate-200 text-[#09090B] text-sm placeholder-[#71717A] rounded-lg px-3 py-2 focus:outline-none focus:border-[#A855F7] w-56 transition-colors"
+            style={{ fontFamily: "'Lexend', sans-serif" }}
+          />
+          <button
+            type="submit"
+            disabled={searchLoading}
+            className="bg-[#A855F7] hover:bg-[#7C3AED] text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors disabled:opacity-50 cursor-pointer"
+            style={{ fontFamily: "'Lexend', sans-serif" }}
+          >
+            {searchLoading ? "..." : "Search"}
+          </button>
+        </div>
+        {searchError && (
+          <p className="text-[#EC4899] text-xs" style={{ fontFamily: "'Lexend', sans-serif" }}>
+            {searchError}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/leaderboard/podium.tsx
+++ b/frontend/src/components/leaderboard/podium.tsx
@@ -1,0 +1,57 @@
+import { motion } from "motion/react";
+import { FaCircleUser } from "react-icons/fa6";
+
+export type PodiumEntry = { name: string; score: number | string };
+
+export function Podium({ top3 }: { top3: [PodiumEntry, PodiumEntry, PodiumEntry] | null }) {
+  if (!top3) return null;
+
+  const [first, second, third] = top3;
+
+  const slots = [
+    { entry: second, rank: 2, height: "h-16", color: "bg-[#A855F7]", labelColor: "text-[#A855F7]" },
+    { entry: first,  rank: 1, height: "h-24", color: "bg-[#C084FC]", labelColor: "text-[#C084FC]", showAvatar: true },
+    { entry: third,  rank: 3, height: "h-12", color: "bg-[#7C3AED]", labelColor: "text-[#7C3AED]" },
+  ] as const;
+
+  return (
+    <div className="flex items-end justify-center gap-3 mb-8">
+      {slots.map(({ entry, rank, height, color, labelColor, showAvatar }, i) => (
+        <motion.div
+          key={rank}
+          className="flex flex-col items-center gap-1.5 w-28"
+          initial={{ opacity: 0, y: 24, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ delay: 0.12 + i * 0.07, duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {showAvatar && (
+            <FaCircleUser className="text-[#1e1e24] mb-1" size={28} />
+          )}
+          <p
+            className="text-xs font-medium truncate max-w-full text-center"
+            style={{ fontFamily: "'Lexend', sans-serif", color: "#1e1e24" }}
+            title={entry.name}
+          >
+            {entry.name}
+          </p>
+          <p
+            className={`text-xs font-semibold ${labelColor}`}
+            style={{ fontFamily: "'JetBrains Mono', monospace" }}
+          >
+            {typeof entry.score === "number" ? entry.score.toLocaleString() : entry.score} pts
+          </p>
+          <div
+            className={`w-full ${height} ${color} rounded-t-lg flex items-start justify-center pt-2`}
+          >
+            <span
+              className="text-white font-bold text-sm"
+              style={{ fontFamily: "'Orbitron', sans-serif" }}
+            >
+              {rank}
+            </span>
+          </div>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/leaderboard/table.tsx
+++ b/frontend/src/components/leaderboard/table.tsx
@@ -1,0 +1,205 @@
+export type LeaderboardEntry = {
+  discord_username: string;
+  discord_id: string;
+  username: string;
+  points: number;
+};
+
+export type AllTimeEntry = {
+  discord_username: string;
+  discord_id: string;
+  username: string;
+  total_points: number;
+  total_wins: number;
+};
+
+const PAGE_SIZE = 10;
+
+function CurrentTable({
+  data,
+  page,
+}: {
+  data: LeaderboardEntry[];
+  page: number;
+}) {
+  return (
+    <table className="w-full">
+      <thead>
+        <tr className="border-b border-slate-100">
+          {["#", "Discord", "LeetCode", "Points"].map((col, i) => (
+            <th
+              key={col}
+              className={`px-4 py-3 text-[#71717A] text-xs uppercase tracking-wider ${i === 3 ? "text-right" : "text-left"} ${i === 0 ? "w-12" : ""}`}
+              style={{ fontFamily: "'Lexend', sans-serif" }}
+            >
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((entry, i) => {
+          const rank = page * PAGE_SIZE + i;
+          return (
+            <tr
+              key={entry.discord_id}
+              className={`border-b border-slate-100 last:border-0 transition-colors hover:bg-[#A855F7]/5 ${rank === 0 ? "bg-[#A855F7]/10" : ""}`}
+            >
+              <td
+                className="px-4 py-3 text-sm"
+                style={{
+                  fontFamily: "'JetBrains Mono', monospace",
+                  color: rank === 0 ? "#A855F7" : "#71717A",
+                }}
+              >
+                {rank + 1}
+              </td>
+              <td
+                className="px-4 py-3 text-[#09090B] text-sm"
+                style={{ fontFamily: "'Lexend', sans-serif" }}
+              >
+                {entry.discord_username}
+              </td>
+              <td
+                className="px-4 py-3 text-[#71717A] text-sm"
+                style={{ fontFamily: "'Lexend', sans-serif" }}
+              >
+                {entry.username}
+              </td>
+              <td
+                className="px-4 py-3 text-right text-[#09090B] text-sm"
+                style={{ fontFamily: "'JetBrains Mono', monospace" }}
+              >
+                {entry.points}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function AllTimeTable({
+  data,
+  page,
+}: {
+  data: AllTimeEntry[];
+  page: number;
+}) {
+  return (
+    <table className="w-full">
+      <thead>
+        <tr className="border-b border-slate-100">
+          {["#", "Discord", "LeetCode", "Points", "Wins"].map((col, i) => (
+            <th
+              key={col}
+              className={`px-4 py-3 text-[#71717A] text-xs uppercase tracking-wider ${i >= 3 ? "text-right" : "text-left"} ${i === 0 ? "w-12" : ""}`}
+              style={{ fontFamily: "'Lexend', sans-serif" }}
+            >
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((entry, i) => {
+          const rank = page * PAGE_SIZE + i;
+          return (
+            <tr
+              key={entry.discord_id}
+              className={`border-b border-slate-100 last:border-0 transition-colors hover:bg-[#A855F7]/5 ${rank === 0 ? "bg-[#A855F7]/10" : ""}`}
+            >
+              <td
+                className="px-4 py-3 text-sm"
+                style={{
+                  fontFamily: "'JetBrains Mono', monospace",
+                  color: rank === 0 ? "#A855F7" : "#71717A",
+                }}
+              >
+                {rank + 1}
+              </td>
+              <td
+                className="px-4 py-3 text-[#09090B] text-sm"
+                style={{ fontFamily: "'Lexend', sans-serif" }}
+              >
+                {entry.discord_username}
+              </td>
+              <td
+                className="px-4 py-3 text-[#71717A] text-sm"
+                style={{ fontFamily: "'Lexend', sans-serif" }}
+              >
+                {entry.username}
+              </td>
+              <td
+                className="px-4 py-3 text-right text-[#09090B] text-sm"
+                style={{ fontFamily: "'JetBrains Mono', monospace" }}
+              >
+                {entry.total_points.toLocaleString()}
+              </td>
+              <td
+                className="px-4 py-3 text-right text-sm"
+                style={{ fontFamily: "'JetBrains Mono', monospace", color: "#FBBF24" }}
+              >
+                {entry.total_wins}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+export function LeaderboardTable({
+  isAllTime,
+  pagedData,
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  isAllTime: boolean;
+  pagedData: LeaderboardEntry[] | AllTimeEntry[];
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}) {
+  return (
+    <>
+      <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden shadow-sm">
+        {isAllTime ? (
+          <AllTimeTable data={pagedData as AllTimeEntry[]} page={page} />
+        ) : (
+          <CurrentTable data={pagedData as LeaderboardEntry[]} page={page} />
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <button
+            onClick={() => onPageChange(page - 1)}
+            disabled={page === 0}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-white border border-slate-200 text-[#71717A] hover:text-[#09090B] transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            style={{ fontFamily: "'Lexend', sans-serif" }}
+          >
+            Previous
+          </button>
+          <span
+            className="text-sm text-[#71717A]"
+            style={{ fontFamily: "'JetBrains Mono', monospace" }}
+          >
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            onClick={() => onPageChange(page + 1)}
+            disabled={page >= totalPages - 1}
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-white border border-slate-200 text-[#71717A] hover:text-[#09090B] transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            style={{ fontFamily: "'Lexend', sans-serif" }}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/leaderboard/userModal.tsx
+++ b/frontend/src/components/leaderboard/userModal.tsx
@@ -1,0 +1,198 @@
+import { FaDiscord, FaTrophy } from "react-icons/fa6";
+import { FaXmark } from "react-icons/fa6";
+import {
+  SiLeetcode,
+  SiPython,
+  SiJavascript,
+  SiTypescript,
+  SiGo,
+  SiRust,
+  SiKotlin,
+  SiSwift,
+  SiScala,
+  SiRuby,
+} from "react-icons/si";
+import type { IconType } from "react-icons";
+
+export type Submission = {
+  title: string;
+  titleSlug: string;
+  timestamp: string;
+  statusDisplay: string;
+  lang: string;
+};
+
+export type UserData = {
+  discord_username: string;
+  leetcode_username: string;
+  ranking: number;
+  local_ranking: string;
+  points: number;
+  wins: number;
+  avatar: string;
+  problems: {
+    count: number;
+    submission: Submission[];
+  };
+};
+
+const langIcons: Record<string, IconType> = {
+  python3: SiPython,
+  python: SiPython,
+  javascript: SiJavascript,
+  typescript: SiTypescript,
+  go: SiGo,
+  rust: SiRust,
+  kotlin: SiKotlin,
+  swift: SiSwift,
+  scala: SiScala,
+  ruby: SiRuby,
+};
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(parseInt(timestamp) * 1000);
+  const diff = Date.now() - date.getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.floor(days / 7)}w ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+export function LeaderboardUserModal({
+  userData,
+  onClose,
+}: {
+  userData: UserData;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-md bg-white border border-slate-200 rounded-2xl p-6 mx-4 shadow-[0_24px_80px_rgba(30,30,36,0.14)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-400 hover:text-slate-700 transition-colors cursor-pointer"
+        >
+          <FaXmark size={16} />
+        </button>
+
+        <div className="flex items-center gap-4 mb-6">
+          <img
+            src={userData.avatar}
+            alt={userData.discord_username}
+            className="w-14 h-14 rounded-full border-2 border-[#A855F7]"
+          />
+          <div>
+            <div
+              className="flex items-center gap-2 text-[#1e1e24] font-semibold"
+              style={{ fontFamily: "'Lexend', sans-serif" }}
+            >
+              <FaDiscord className="text-[#A855F7]" />
+              {userData.discord_username}
+            </div>
+            <a
+              href={`https://leetcode.com/u/${userData.leetcode_username}`}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1.5 text-[#2DD4BF] text-sm hover:underline mt-0.5"
+              style={{ fontFamily: "'Lexend', sans-serif" }}
+            >
+              <SiLeetcode size={12} />
+              {userData.leetcode_username}
+            </a>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 mb-6">
+          {[
+            { label: "Global Rank", value: `#${userData.ranking.toLocaleString()}`, mono: true },
+            { label: "Local Rank", value: `#${userData.local_ranking}`, mono: true },
+            { label: "Points", value: String(userData.points), mono: true },
+          ].map(({ label, value, mono }) => (
+            <div key={label} className="bg-slate-50 rounded-xl p-3 border border-slate-100">
+              <p
+                className="text-[#71717A] text-xs uppercase tracking-wider mb-1"
+                style={{ fontFamily: "'Lexend', sans-serif" }}
+              >
+                {label}
+              </p>
+              <p
+                className="text-[#1e1e24] text-lg"
+                style={{ fontFamily: mono ? "'JetBrains Mono', monospace" : "'Lexend', sans-serif" }}
+              >
+                {value}
+              </p>
+            </div>
+          ))}
+          <div className="bg-slate-50 rounded-xl p-3 border border-slate-100">
+            <p
+              className="text-[#71717A] text-xs uppercase tracking-wider mb-1"
+              style={{ fontFamily: "'Lexend', sans-serif" }}
+            >
+              Wins
+            </p>
+            <p
+              className="text-[#1e1e24] text-lg flex items-center gap-1.5"
+              style={{ fontFamily: "'JetBrains Mono', monospace" }}
+            >
+              <FaTrophy className="text-[#FBBF24] text-base" />
+              {userData.wins}
+            </p>
+          </div>
+        </div>
+
+        <p
+          className="text-[#71717A] text-xs uppercase tracking-wider mb-3"
+          style={{ fontFamily: "'Lexend', sans-serif" }}
+        >
+          Recent Submissions
+        </p>
+        <div className="space-y-2">
+          {userData.problems.submission.slice(0, 5).map((sub, i) => {
+            const LangIcon = langIcons[sub.lang] ?? null;
+            return (
+              <div
+                key={i}
+                className="flex items-center justify-between gap-2 bg-slate-50 rounded-lg px-3 py-2 border border-slate-100"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  {LangIcon && <LangIcon className="text-[#A855F7] shrink-0" size={14} />}
+                  <a
+                    href={`https://leetcode.com/problems/${sub.titleSlug}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[#1e1e24] text-sm truncate hover:text-[#A855F7] transition-colors"
+                    style={{ fontFamily: "'Lexend', sans-serif" }}
+                  >
+                    {sub.title}
+                  </a>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span
+                    className="text-[#2DD4BF] text-xs"
+                    style={{ fontFamily: "'JetBrains Mono', monospace" }}
+                  >
+                    {sub.statusDisplay}
+                  </span>
+                  <span
+                    className="text-[#71717A] text-xs"
+                    style={{ fontFamily: "'JetBrains Mono', monospace" }}
+                  >
+                    {formatTimestamp(sub.timestamp)}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/leaderboard.tsx
+++ b/frontend/src/routes/leaderboard.tsx
@@ -1,5 +1,142 @@
-import { PageShell } from "../components/page-shell";
+import { useEffect, useState } from "react";
+import { motion } from "motion/react";
+import { fetchUser, fetchLeaderboard, fetchLeaderboardHistory } from "../api/leaderboard";
+import { LeaderboardControls } from "../components/leaderboard/controls";
+import { LeaderboardTable, type LeaderboardEntry, type AllTimeEntry } from "../components/leaderboard/table";
+import { LeaderboardUserModal, type UserData } from "../components/leaderboard/userModal";
+import { Podium } from "../components/leaderboard/podium";
+
+const PAGE_SIZE = 10;
 
 export default function Leaderboard() {
-  return <PageShell title="Leaderboard" />;
+  const [leaderboardData, setLeaderboardData] = useState<LeaderboardEntry[] | null>(null);
+  const [allTimeData, setAllTimeData] = useState<AllTimeEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [userData, setUserData] = useState<UserData | null>(null);
+  const [userModal, setUserModal] = useState(false);
+  const [isAllTime, setIsAllTime] = useState(false);
+  const [lbPage, setLbPage] = useState(0);
+  const [allTimePage, setAllTimePage] = useState(0);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  const page = isAllTime ? allTimePage : lbPage;
+  const setPage = isAllTime ? setAllTimePage : setLbPage;
+  const activeData = isAllTime ? allTimeData : leaderboardData;
+  const totalPages = Math.ceil((activeData?.length ?? 0) / PAGE_SIZE);
+  const pagedData = activeData?.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE) ?? [];
+
+  const top3 =
+    activeData && activeData.length >= 3
+      ? ([0, 1, 2].map((i) => ({
+          name: activeData[i].discord_username,
+          score: isAllTime
+            ? (activeData[i] as AllTimeEntry).total_points
+            : (activeData[i] as LeaderboardEntry).points,
+        })) as [{ name: string; score: number }, { name: string; score: number }, { name: string; score: number }])
+      : null;
+
+  useEffect(() => {
+    Promise.all([fetchLeaderboard(), fetchLeaderboardHistory()])
+      .then(([lb, history]) => {
+        setLeaderboardData(lb);
+        setAllTimeData(history);
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!searchQuery.trim()) return;
+    setSearchLoading(true);
+    setSearchError(null);
+    try {
+      const user = await fetchUser(searchQuery.trim());
+      setUserData(user);
+      setUserModal(true);
+    } catch {
+      setSearchError("User not found.");
+    } finally {
+      setSearchLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-transparent flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-[#A855F7] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="min-h-screen bg-transparent flex items-center justify-center text-white"
+        style={{ fontFamily: "'Lexend', sans-serif" }}
+      >
+        Failed to load leaderboard: {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-transparent px-4 py-10">
+      <div className="max-w-4xl mx-auto">
+        <motion.h1
+          className="font-['Orbitron',sans-serif] leading-[0.95] tracking-[-0.04em] text-[#1e1e24] text-3xl text-center mb-8"
+          initial={{ opacity: 0, y: 14 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        >
+          Code For All Weekly Leaderboard
+        </motion.h1>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1, duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <Podium top3={top3} />
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.18, duration: 0.38, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <LeaderboardControls
+            isAllTime={isAllTime}
+            onToggle={(val) => { setIsAllTime(val); setLbPage(0); setAllTimePage(0); }}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            onSearchSubmit={handleSearch}
+            searchLoading={searchLoading}
+            searchError={searchError}
+          />
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.26, duration: 0.38, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <LeaderboardTable
+            isAllTime={isAllTime}
+            pagedData={pagedData}
+            page={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+          />
+        </motion.div>
+      </div>
+
+      {userModal && userData && (
+        <LeaderboardUserModal userData={userData} onClose={() => setUserModal(false)} />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
  ### Description                                                                                                                                                                                           
  - Implemented LeetCode Leaderboard webpage
  - Used existing LeetCode Leaderboard API to fetch current / all-time user rankings                                                                                                                        
  - Added user search by Discord or LeetCode username, displaying stats (rank, points, wins) and recent submissions in a modal

## New files
  - `src/api/leaderboard.ts` — API calls for current rankings, history, and per-user lookup (tries Discord username first, falls back to LeetCode)
  - `src/components/leaderboard/podium.tsx` — animated top-3 podium
  - `src/components/leaderboard/table.tsx` — paginated table with separate column sets for weekly vs all-time views
  - `src/components/leaderboard/controls.tsx` — toggle (Current Rankings / All-Time) and user search form
  - `src/components/leaderboard/userModal.tsx` — user detail modal with submission history and language icons
  - `src/routes/leaderboard.tsx` — page entry point, wires state and API calls together

<img width="1901" height="930" alt="LC_Leaderboard" src="https://github.com/user-attachments/assets/019cd473-643a-480f-afea-4459e3a65488" />

<img width="1908" height="943" alt="image" src="https://github.com/user-attachments/assets/239eaa10-0b2b-4b53-bdad-a953a703d39f" />